### PR TITLE
remove onSocketClose callback res

### DIFF
--- a/docs/api/request/websocket.md
+++ b/docs/api/request/websocket.md
@@ -210,7 +210,7 @@ uni.onSocketOpen(function () {
   uni.closeSocket();
 });
 
-uni.onSocketClose(function (res) {
+uni.onSocketClose(function () {
   console.log('WebSocket 已关闭！');
 });
 ```


### PR DESCRIPTION
有一个问题请教一下：
我看文档上onSocketClose callback 没有回调参数， 请问一下为什么没有？ 其他平台都有的